### PR TITLE
Refactor to CLImate for better argument parsing and output

### DIFF
--- a/bin/phpa
+++ b/bin/phpa
@@ -12,5 +12,5 @@ foreach ($autoloaders as $autoloader) {
 
 ini_set('xdebug.max_nesting_level', 3000);
 
-$cli = new \PhpAssumptions\Cli();
-$cli->handle(array_splice($argv, 1));
+$cli = new \PhpAssumptions\Cli(new \League\CLImate\CLImate());
+$cli->handle($argv);

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         }
     ],
     "require": {
-        "nikic/php-parser": "^1.0"
+        "nikic/php-parser": "^1.0",
+        "league/climate": "^3.1"
     },
     "require-dev": {
         "phpspec/phpspec": "^2.2",

--- a/src/PhpAssumptions/Cli.php
+++ b/src/PhpAssumptions/Cli.php
@@ -30,7 +30,7 @@ class Cli
             'format' => [
                 'prefix'       => 'f',
                 'longPrefix'   => 'format',
-                'description'  => 'Format (pretty, xml)',
+                'description'  => 'Format (pretty)',
                 'defaultValue' => 'pretty',
             ],
         ]);

--- a/src/PhpAssumptions/Output/PrettyOutput.php
+++ b/src/PhpAssumptions/Output/PrettyOutput.php
@@ -2,14 +2,27 @@
 
 namespace PhpAssumptions\Output;
 
-use PhpAssumptions\Cli;
+use League\CLImate\CLImate;
 
 class PrettyOutput implements OutputInterface
 {
     /**
+     * @var CLImate
+     */
+    private $cli;
+
+    /**
      * @var array
      */
-    private $buffer = [];
+    private $table = [];
+
+    /**
+     * @param CLImate $cli
+     */
+    public function __construct(CLImate $cli)
+    {
+        $this->cli = $cli;
+    }
 
     /**
      * @param string $file
@@ -18,23 +31,19 @@ class PrettyOutput implements OutputInterface
      */
     public function write($file, $line, $message)
     {
-        $this->buffer[] = [
+        $this->table[] = [
             'file' => $file,
             'line' => $line,
-            'message' => $message
+            'message' => $message,
         ];
     }
 
     public function flush()
     {
-        printf('PHPAssumptions analyser v%s by @rskuipers' . PHP_EOL . PHP_EOL, Cli::VERSION);
-
-        foreach ($this->buffer as $warning) {
-            echo $warning['file'] . ':' . $warning['line'] . ': ' . $warning['message'] . PHP_EOL;
+        if (count($this->table) > 0) {
+            $this->cli->table($this->table)->br();
         }
 
-        echo PHP_EOL;
-
-        echo 'Total warnings: ' . count($this->buffer) . PHP_EOL;
+        $this->cli->out('Total warnings: ' . count($this->table));
     }
 }

--- a/tests/fixtures/MyOtherClass.php
+++ b/tests/fixtures/MyOtherClass.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace fixtures;
+
+class MyOtherClass
+{
+    public function run($cat)
+    {
+        if ($cat !== null) {
+            $cat->meow();
+        }
+    }
+}

--- a/tests/integration/PhpAssumptions/CliTest.php
+++ b/tests/integration/PhpAssumptions/CliTest.php
@@ -2,31 +2,94 @@
 
 namespace integration\PhpAssumptions;
 
+use League\CLImate\Argument\Manager;
+use League\CLImate\CLImate;
 use PhpAssumptions\Cli;
+use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTestCase;
 
 class CliTest extends ProphecyTestCase
 {
     /**
+     * @var Manager
+     */
+    private $argumentManager;
+
+    /**
      * @var Cli
      */
     private $cli;
 
+    /**
+     * @var CLImate
+     */
+    private $climate;
+
     public function setUp()
     {
-        $this->cli = new Cli();
+        $this->argumentManager = $this->prophesize(Manager::class);
+        $this->argumentManager->add(Argument::type('array'))->shouldBeCalled();
+        $this->argumentManager->parse(Argument::type('array'))->shouldBeCalled();
+
+        $this->climate = $this->prophesize(CLImate::class);
+
+        $this->climate->arguments = $this->argumentManager->reveal();
+        $this->climate->out(Argument::containingString('PHPAssumptions analyser'))
+            ->shouldBeCalled()
+            ->willReturn($this->climate);
+
+        $this->climate->br()->shouldBeCalled();
+
+        $this->cli = new Cli($this->climate->reveal());
     }
 
     /**
      * @test
      */
-    public function itShouldDetectWeakAssumption()
+    public function itShouldAnalyseTargetFile()
     {
-        ob_start();
-        $this->cli->handle([fixture('MyClass.php')]);
-        $contents = ob_get_contents();
-        ob_end_clean();
+        $path = fixture('MyClass.php');
 
-        $this->assertContains('MyClass.php:9', $contents);
+        $this->argumentManager->get('format')->shouldBeCalled()->willReturn('pretty');
+        $this->argumentManager->get('path')->shouldBeCalled()->willReturn($path);
+
+        $this->climate->table([[
+            'file' => $path,
+            'line' => 9,
+            'message' => '$dog !== null;'
+        ]])->shouldBeCalled()->willReturn($this->climate);
+
+        $this->climate->out('Total warnings: 1')->shouldBeCalled();
+
+        $this->cli->handle(['phpa', $path]);
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldAnalyseTargetDirectory()
+    {
+        $pathMyClass = fixture('MyClass.php');
+        $pathMyOtherClass = fixture('MyOtherClass.php');
+
+        $this->argumentManager->get('format')->shouldBeCalled()->willReturn('pretty');
+        $this->argumentManager->get('path')->shouldBeCalled()->willReturn(FIXTURES_DIR);
+
+        $this->climate->table([
+            [
+                'file' => $pathMyClass,
+                'line' => 9,
+                'message' => '$dog !== null;'
+            ],
+            [
+                'file' => $pathMyOtherClass,
+                'line' => 9,
+                'message' => '$cat !== null;'
+            ]
+        ])->shouldBeCalled()->willReturn($this->climate);
+
+        $this->climate->out('Total warnings: 2')->shouldBeCalled();
+
+        $this->cli->handle(['phpa', FIXTURES_DIR]);
     }
 }

--- a/tests/spec/PhpAssumptions/CliSpec.php
+++ b/tests/spec/PhpAssumptions/CliSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\PhpAssumptions;
 
+use League\CLImate\Argument\Manager;
+use League\CLImate\CLImate;
 use PhpAssumptions\Cli;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
@@ -11,6 +13,13 @@ use Prophecy\Argument;
  */
 class CliSpec extends ObjectBehavior
 {
+    public function let(CLImate $cli, Manager $argumentManager)
+    {
+        $argumentManager->add(Argument::type('array'))->shouldBeCalled();
+        $cli->arguments = $argumentManager;
+        $this->beConstructedWith($cli);
+    }
+
     public function it_is_initializable()
     {
         $this->shouldHaveType(Cli::class);

--- a/tests/spec/PhpAssumptions/Output/PrettyOutputSpec.php
+++ b/tests/spec/PhpAssumptions/Output/PrettyOutputSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\PhpAssumptions\Output;
 
+use League\CLImate\CLImate;
 use PhpAssumptions\Output\OutputInterface;
 use PhpAssumptions\Output\PrettyOutput;
 use PhpSpec\ObjectBehavior;
@@ -12,6 +13,11 @@ use Prophecy\Argument;
  */
 class PrettyOutputSpec extends ObjectBehavior
 {
+    public function let(CLImate $cli)
+    {
+        $this->beConstructedWith($cli);
+    }
+
     public function it_is_initializable()
     {
         $this->shouldHaveType(PrettyOutput::class);


### PR DESCRIPTION
This PR introduces CLImate to the project, this is in preparation for new XmlOutput to give the option to switch format with CLI argument.

CLImate also offers nice output so the PrettyOutput has been updated to output a table instead.

Closes #7 
