### PR TITLE
Php7 compatibility update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.6",
-        "henrikbjorn/phpspec-code-coverage": "^1.0"
+        "phpspec/prophecy": "~1.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "league/climate": "^3.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^5.6",
         "henrikbjorn/phpspec-code-coverage": "^1.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "nikic/php-parser": "^1.0",
+        "nikic/php-parser": "^2.0",
         "league/climate": "^3.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",
-        "phpspec/prophecy-phpunit": "^1.1",
         "henrikbjorn/phpspec-code-coverage": "^1.0"
     },
     "autoload": {

--- a/src/PhpAssumptions/Analyser.php
+++ b/src/PhpAssumptions/Analyser.php
@@ -35,7 +35,7 @@ class Analyser
     private $result;
 
     /**
-     * @param ParserAbstract $parser
+     * @param ParserAbstract         $parser
      * @param NodeTraverserInterface $nodeTraverser
      */
     public function __construct(

--- a/src/PhpAssumptions/Analyser.php
+++ b/src/PhpAssumptions/Analyser.php
@@ -5,7 +5,7 @@ namespace PhpAssumptions;
 use PhpAssumptions\Output\Result;
 use PhpParser\Node;
 use PhpParser\NodeTraverserInterface;
-use PhpParser\ParserAbstract;
+use PhpParser\Parser\Multiple;
 
 class Analyser
 {
@@ -39,7 +39,7 @@ class Analyser
      * @param NodeTraverserInterface $nodeTraverser
      */
     public function __construct(
-        ParserAbstract $parser,
+        Multiple $parser,
         NodeTraverserInterface $nodeTraverser
     ) {
         $this->parser = $parser;

--- a/src/PhpAssumptions/Cli.php
+++ b/src/PhpAssumptions/Cli.php
@@ -6,9 +6,8 @@ use League\CLImate\CLImate;
 use PhpAssumptions\Output\PrettyOutput;
 use PhpAssumptions\Output\XmlOutput;
 use PhpAssumptions\Parser\NodeVisitor;
-use PhpParser\Lexer;
 use PhpParser\NodeTraverser;
-use PhpParser\Parser;
+use PhpParser\ParserFactory;
 
 class Cli
 {
@@ -18,6 +17,11 @@ class Cli
      * @var CLImate
      */
     private $cli;
+
+    private function createParser() {
+        $parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
+        return $parser;
+    }
 
     public function __construct(CLImate $cli)
     {
@@ -40,6 +44,7 @@ class Cli
                 'defaultValue' => 'phpa.xml',
             ],
         ]);
+        $this->parser = self::createParser();
     }
 
     /**
@@ -68,7 +73,7 @@ class Cli
         $nodeTraverser = new NodeTraverser();
 
         $analyser = new Analyser(
-            new Parser(new Lexer()),
+            $this->parser,
             $nodeTraverser
         );
 

--- a/src/PhpAssumptions/Cli.php
+++ b/src/PhpAssumptions/Cli.php
@@ -18,7 +18,8 @@ class Cli
      */
     private $cli;
 
-    private function createParser() {
+    private function createParser()
+    {
         $parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
         return $parser;
     }
@@ -26,7 +27,8 @@ class Cli
     public function __construct(CLImate $cli)
     {
         $this->cli = $cli;
-        $this->cli->arguments->add([
+        $this->cli->arguments->add(
+            [
             'path' => [
                 'description' => 'The path to analyse',
                 'required' => true,
@@ -43,7 +45,8 @@ class Cli
                 'description' => 'Output file',
                 'defaultValue' => 'phpa.xml',
             ],
-        ]);
+            ]
+        );
         $this->parser = self::createParser();
     }
 

--- a/src/PhpAssumptions/Detector.php
+++ b/src/PhpAssumptions/Detector.php
@@ -81,7 +81,7 @@ class Detector
     }
 
     /**
-     * @param Expr $condition
+     * @param Expr   $condition
      * @param string $left
      * @param string $right
      * @return bool

--- a/src/PhpAssumptions/Output/PrettyOutput.php
+++ b/src/PhpAssumptions/Output/PrettyOutput.php
@@ -28,11 +28,13 @@ class PrettyOutput implements OutputInterface
             $this->cli->table($result->getAssumptions())->br();
         }
 
-        $this->cli->out(sprintf(
-            '%d out of %d boolean expressions are assumptions (%d%%)',
-            $result->getAssumptionsCount(),
-            $result->getBoolExpressionsCount(),
-            $result->getPercentage()
-        ));
+        $this->cli->out(
+            sprintf(
+                '%d out of %d boolean expressions are assumptions (%d%%)',
+                $result->getAssumptionsCount(),
+                $result->getBoolExpressionsCount(),
+                $result->getPercentage()
+            )
+        );
     }
 }

--- a/src/PhpAssumptions/Output/Result.php
+++ b/src/PhpAssumptions/Output/Result.php
@@ -16,7 +16,7 @@ class Result
 
     /**
      * @param string $file
-     * @param int $line
+     * @param int    $line
      * @param string $message
      */
     public function addAssumption($file, $line, $message)

--- a/src/PhpAssumptions/Output/XmlOutput.php
+++ b/src/PhpAssumptions/Output/XmlOutput.php
@@ -29,7 +29,7 @@ class XmlOutput implements OutputInterface
 
     /**
      * @param CLImate $cli
-     * @param string $file
+     * @param string  $file
      */
     public function __construct(CLImate $cli, $file)
     {

--- a/tests/PhpAssumptions/AnalyserTest.php
+++ b/tests/PhpAssumptions/AnalyserTest.php
@@ -6,7 +6,7 @@ use PhpAssumptions\Analyser;
 use PhpAssumptions\Output\OutputInterface;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
-use PhpParser\Parser;
+use PhpParser\ParserFactory;
 use Prophecy\Argument;
 
 class AnalyserTest extends \PHPUnit_Framework_TestCase
@@ -39,11 +39,11 @@ class AnalyserTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->node = $this->prophesize(Node::class);
-        $this->parser = $this->prophesize(Parser::class);
+        $this->parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
         $this->output = $this->prophesize(OutputInterface::class);
         $this->nodeTraverser = $this->prophesize(NodeTraverser::class);
         $this->analyser = new Analyser(
-            $this->parser->reveal(),
+            $this->parser,
             $this->nodeTraverser->reveal(),
             $this->output->reveal()
         );
@@ -57,7 +57,8 @@ class AnalyserTest extends \PHPUnit_Framework_TestCase
         $files = [fixture('MyClass.php')];
         $nodes = [$this->node];
 
-        $this->parser->parse(Argument::type('string'))->shouldBeCalled()->willReturn($nodes);
+        $parseRes = $this->parser->parse(Argument::type('string'));
+        //$this->parser->parse(Argument::type('string'))->shouldBeCalled()->willReturn($nodes);
 
         $this->nodeTraverser->traverse($nodes)->shouldBeCalled();
 

--- a/tests/PhpAssumptions/AnalyserTest.php
+++ b/tests/PhpAssumptions/AnalyserTest.php
@@ -8,9 +8,8 @@ use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\Parser;
 use Prophecy\Argument;
-use Prophecy\PhpUnit\ProphecyTestCase;
 
-class AnalyserTest extends ProphecyTestCase
+class AnalyserTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var Parser

--- a/tests/PhpAssumptions/AnalyserTest.php
+++ b/tests/PhpAssumptions/AnalyserTest.php
@@ -4,9 +4,9 @@ namespace tests\PhpAssumptions;
 
 use PhpAssumptions\Analyser;
 use PhpAssumptions\Output\OutputInterface;
+use PhpParser\Parser\Multiple;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
-use PhpParser\ParserFactory;
 use Prophecy\Argument;
 
 class AnalyserTest extends \PHPUnit_Framework_TestCase
@@ -39,11 +39,11 @@ class AnalyserTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->node = $this->prophesize(Node::class);
-        $this->parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
+        $this->parser = $this->prophesize(Multiple::class);
         $this->output = $this->prophesize(OutputInterface::class);
         $this->nodeTraverser = $this->prophesize(NodeTraverser::class);
         $this->analyser = new Analyser(
-            $this->parser,
+            $this->parser->reveal(),
             $this->nodeTraverser->reveal(),
             $this->output->reveal()
         );
@@ -58,7 +58,7 @@ class AnalyserTest extends \PHPUnit_Framework_TestCase
         $nodes = [$this->node];
 
         $parseRes = $this->parser->parse(Argument::type('string'));
-        //$this->parser->parse(Argument::type('string'))->shouldBeCalled()->willReturn($nodes);
+        $this->parser->parse(Argument::type('string'))->shouldBeCalled()->willReturn($nodes);
 
         $this->nodeTraverser->traverse($nodes)->shouldBeCalled();
 

--- a/tests/PhpAssumptions/CliTest.php
+++ b/tests/PhpAssumptions/CliTest.php
@@ -6,9 +6,8 @@ use League\CLImate\Argument\Manager;
 use League\CLImate\CLImate;
 use PhpAssumptions\Cli;
 use Prophecy\Argument;
-use Prophecy\PhpUnit\ProphecyTestCase;
 
-class CliTest extends ProphecyTestCase
+class CliTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var Cli

--- a/tests/PhpAssumptions/DetectorTest.php
+++ b/tests/PhpAssumptions/DetectorTest.php
@@ -3,8 +3,7 @@
 namespace tests\PhpAssumptions;
 
 use PhpAssumptions\Detector;
-use PhpParser\Lexer;
-use PhpParser\Parser;
+use PhpParser\ParserFactory;
 
 class NodeVisitorTest extends \PHPUnit_Framework_TestCase
 {
@@ -20,7 +19,7 @@ class NodeVisitorTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->parser = new Parser(new Lexer());
+        $this->parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
         $this->detector = new Detector();
     }
 

--- a/tests/PhpAssumptions/DetectorTest.php
+++ b/tests/PhpAssumptions/DetectorTest.php
@@ -5,9 +5,8 @@ namespace tests\PhpAssumptions;
 use PhpAssumptions\Detector;
 use PhpParser\Lexer;
 use PhpParser\Parser;
-use Prophecy\PhpUnit\ProphecyTestCase;
 
-class NodeVisitorTest extends ProphecyTestCase
+class NodeVisitorTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var Parser

--- a/tests/PhpAssumptions/ExampleTest.php
+++ b/tests/PhpAssumptions/ExampleTest.php
@@ -9,9 +9,8 @@ use PhpParser\Lexer;
 use PhpParser\NodeTraverser;
 use PhpParser\Parser;
 use PhpParser\PrettyPrinter\Standard;
-use Prophecy\PhpUnit\ProphecyTestCase;
 
-class ExampleTest extends ProphecyTestCase
+class ExampleTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var Analyser

--- a/tests/PhpAssumptions/ExampleTest.php
+++ b/tests/PhpAssumptions/ExampleTest.php
@@ -5,9 +5,8 @@ namespace tests;
 use PhpAssumptions\Analyser;
 use PhpAssumptions\Detector;
 use PhpAssumptions\Parser\NodeVisitor;
-use PhpParser\Lexer;
 use PhpParser\NodeTraverser;
-use PhpParser\Parser;
+use PhpParser\ParserFactory;
 use PhpParser\PrettyPrinter\Standard;
 
 class ExampleTest extends \PHPUnit_Framework_TestCase
@@ -20,7 +19,7 @@ class ExampleTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $nodeTraverser = new NodeTraverser();
-        $this->analyser = new Analyser(new Parser(new Lexer()), $nodeTraverser);
+        $this->analyser = new Analyser((new ParserFactory)->create(ParserFactory::PREFER_PHP7), $nodeTraverser);
         $nodeTraverser->addVisitor(new NodeVisitor($this->analyser, new Detector()));
     }
 

--- a/tests/PhpAssumptions/Output/PrettyOutputTest.php
+++ b/tests/PhpAssumptions/Output/PrettyOutputTest.php
@@ -6,9 +6,8 @@ use League\CLImate\CLImate;
 use PhpAssumptions\Output\PrettyOutput;
 use PhpAssumptions\Output\Result;
 use Prophecy\Argument;
-use Prophecy\PhpUnit\ProphecyTestCase;
 
-class PrettyOutputTest extends ProphecyTestCase
+class PrettyOutputTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var PrettyOutput

--- a/tests/PhpAssumptions/Output/XmlOutputTest.php
+++ b/tests/PhpAssumptions/Output/XmlOutputTest.php
@@ -5,10 +5,9 @@ namespace tests\PhpAssumptions\Output;
 use League\CLImate\CLImate;
 use PhpAssumptions\Cli;
 use PhpAssumptions\Output\Result;
-use Prophecy\PhpUnit\ProphecyTestCase;
 use PhpAssumptions\Output\XmlOutput;
 
-class XmlOutputTest extends ProphecyTestCase
+class XmlOutputTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var XmlOutput

--- a/tests/PhpAssumptions/Parser/NodeVisitorTest.php
+++ b/tests/PhpAssumptions/Parser/NodeVisitorTest.php
@@ -8,9 +8,8 @@ use PhpAssumptions\Parser\NodeVisitor;
 use PhpParser\Node;
 use PhpParser\PrettyPrinter\Standard;
 use Prophecy\Argument;
-use Prophecy\PhpUnit\ProphecyTestCase;
 
-class NodeVisitorTest extends ProphecyTestCase
+class NodeVisitorTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var NodeVisitor

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,6 @@
 <?php
 
+require __DIR__ . '/../vendor/autoload.php';
 define('FIXTURES_DIR', dirname(__FILE__) . DIRECTORY_SEPARATOR . 'fixtures');
 
 function fixture($filename)


### PR DESCRIPTION
This set of commits fixes the issue of #15 that I recently reported.

All tests were passing still on my end and this now allows me to run with out commenting out GREs. However once I started using `./vendor/bin/phpunit` I got all sorts of errors in tests. I made an attempt at fixing most of them but I wasn't familiar enough with the packing and how to properly fix the remaining test that has issues.