### PR TITLE
Add an option to ignore paths

### DIFF
--- a/src/PhpAssumptions/Analyser.php
+++ b/src/PhpAssumptions/Analyser.php
@@ -6,6 +6,7 @@ use PhpAssumptions\Output\Result;
 use PhpParser\Node;
 use PhpParser\NodeTraverserInterface;
 use PhpParser\Parser\Multiple;
+use PhpParser\ParserAbstract;
 
 class Analyser
 {
@@ -35,16 +36,24 @@ class Analyser
     private $result;
 
     /**
-     * @param ParserAbstract         $parser
-     * @param NodeTraverserInterface $nodeTraverser
+     * @var array|\string[]
+     */
+    private $excludes = [];
+
+    /**
+     * @param ParserAbstract|Multiple $parser
+     * @param NodeTraverserInterface  $nodeTraverser
+     * @param string[]                $excludes
      */
     public function __construct(
         Multiple $parser,
-        NodeTraverserInterface $nodeTraverser
+        NodeTraverserInterface $nodeTraverser,
+        $excludes = []
     ) {
         $this->parser = $parser;
         $this->traverser = $nodeTraverser;
         $this->result = new Result();
+        $this->excludes = $excludes;
     }
 
     /**
@@ -54,6 +63,9 @@ class Analyser
     public function analyse(array $files)
     {
         foreach ($files as $file) {
+            if (in_array($file, $this->excludes, true)) {
+                continue;
+            }
             $this->currentFilePath = $file;
             $this->currentFile = [];
             $statements = $this->parser->parse(file_get_contents($file));

--- a/tests/PhpAssumptions/AnalyserTest.php
+++ b/tests/PhpAssumptions/AnalyserTest.php
@@ -45,7 +45,7 @@ class AnalyserTest extends \PHPUnit_Framework_TestCase
         $this->analyser = new Analyser(
             $this->parser->reveal(),
             $this->nodeTraverser->reveal(),
-            $this->output->reveal()
+            [fixture('MyOtherClass.php')]
         );
     }
 
@@ -55,6 +55,22 @@ class AnalyserTest extends \PHPUnit_Framework_TestCase
     public function itShouldAnalyseAllFiles()
     {
         $files = [fixture('MyClass.php')];
+        $nodes = [$this->node];
+
+        $parseRes = $this->parser->parse(Argument::type('string'));
+        $this->parser->parse(Argument::type('string'))->shouldBeCalled()->willReturn($nodes);
+
+        $this->nodeTraverser->traverse($nodes)->shouldBeCalled();
+
+        $this->analyser->analyse($files);
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldIgnoreExcludeFiles()
+    {
+        $files = [fixture('MyClass.php'), fixture('MyOtherClass.php')];
         $nodes = [$this->node];
 
         $parseRes = $this->parser->parse(Argument::type('string'));


### PR DESCRIPTION
Add an option to allow some files (or directories) to be excluded from the analyze.

I encounter a case where I wanted to check a project root path, but I get a lots of errors from the `vendor` directory.